### PR TITLE
[notebooks] Add Debug Action for External Link to Notebook State

### DIFF
--- a/components/crud-web-apps/jupyter/Makefile
+++ b/components/crud-web-apps/jupyter/Makefile
@@ -1,6 +1,7 @@
 GIT_TAG ?= $(shell git describe --tags --always)
 IMG ?= public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
 DOCKERFILE ?= jupyter/Dockerfile
+UNIX_TS ?= $(shell date +%s)
 
 docker-build:
 	cd ../ && docker build -t ${IMG}:${GIT_TAG} -f ${DOCKERFILE} .
@@ -9,3 +10,14 @@ docker-push:
 	docker push $(IMG):$(GIT_TAG)
 
 image: docker-build docker-push
+
+HARBOR_IMG ?= harbor.cloud.aurora.tech/library/notebooks/jupyter-web-app
+harbor-build:
+	cd ../ && 
+
+harbor-push:
+	docker push $(HARBOR_IMG):$(GIT_TAG)-$(UNIX_TS)
+
+harbor-image:
+	cd ../ && docker build -t ${HARBOR_IMG}:${GIT_TAG}-$(UNIX_TS) -f ${DOCKERFILE} .
+	docker push $(HARBOR_IMG):$(GIT_TAG)-$(UNIX_TS)

--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -113,16 +113,21 @@ def get_storage_class(vol):
 
 
 # Functions for transforming the data from k8s api
-def notebook_dict_from_k8s_obj(notebook):
+def notebook_dict_from_k8s_obj(notebook, config):
     cntr = notebook["spec"]["template"]["spec"]["containers"][0]
     server_type = None
     if notebook["metadata"].get("annotations"):
         annotations = notebook["metadata"]["annotations"]
         server_type = annotations.get("notebooks.kubeflow.org/server-type")
+    name = notebook["metadata"]["name"]
+    namespace = notebook["metadata"]["namespace"]
+    dashLink = ""
+    if "dashLinkFormat" in config:
+        dashLink = config["dashLinkFormat"].format(namespace=namespace, name=name)
 
     return {
-        "name": notebook["metadata"]["name"],
-        "namespace": notebook["metadata"]["namespace"],
+        "name": name,
+        "namespace": namespace,
         "serverType": server_type,
         "age": helpers.get_uptime(notebook["metadata"]["creationTimestamp"]),
         "image": cntr["image"],
@@ -132,4 +137,5 @@ def notebook_dict_from_k8s_obj(notebook):
         "memory": cntr["resources"]["requests"]["memory"],
         "volumes": [v["name"] for v in cntr["volumeMounts"]],
         "status": status.process_status(notebook),
+        "dashLink": dashLink
     }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -113,7 +113,6 @@ export const defaultConfig: TableConfig = {
       matColumnDef: 'volumes',
       value: new MenuValue({ field: 'volumes', itemsIcon: 'storage' }),
     },
-
     {
       matHeaderCellDef: '',
       matColumnDef: 'actions',

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
@@ -21,12 +21,14 @@ export interface NotebookResponseObject {
   };
   environment: string;
   shortImage: string;
+  dashLink: string;
 }
 
 export interface NotebookProcessedObject extends NotebookResponseObject {
   deleteAction?: string;
   connectAction?: string;
   startStopAction?: string;
+  debugAction?: string;
 }
 
 export interface NotebookFormObject {


### PR DESCRIPTION
- Add dashLink to object model for NotebookResponseObject.
- Add code to notebook index frontend that detects when dashLink is a non-empty string and adds or removes the "debug" column to the table config.
- Add a handler to the new debug action button to open the provided link.
- Add logic to the backend that detects when a dashLink template is provided in the configmap, and provides the instantiated template along with the notebook.