### PR TITLE
(bug) Set Reload Interval To Reduce Calls to Cloud File Systems

### DIFF
--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -255,6 +255,8 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 							WorkingDir:      "/",
 							Args: []string{
 								"--logdir=" + mountpath,
+								"--reload_interval",
+								"120",
 								"--bind_all",
 							},
 							Ports: []corev1.ContainerPort{
@@ -374,8 +376,8 @@ func extractPVCSubPath(path string) string {
 	}
 }
 
-//Searches a corev1.PodList for running pods and returns
-//a running corev1.Pod (if exists)
+// Searches a corev1.PodList for running pods and returns
+// a running corev1.Pod (if exists)
 func findRunningPod(pods *corev1.PodList) corev1.Pod {
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == "Running" {
@@ -435,9 +437,9 @@ func generateNodeAffinity(affinity *corev1.Affinity, pvcname string, r *Tensorbo
 	return nil
 }
 
-//Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
-//'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
-//returned boolean is set to 'false', so that the scheduling functionality is off by default.
+// Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
+// 'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
+// returned boolean is set to 'false', so that the scheduling functionality is off by default.
 func rwoPVCScheduling() (error, bool) {
 	if value, exists := os.LookupEnv("RWO_PVC_SCHEDULING"); !exists || value == "false" || value == "False" || value == "FALSE" {
 		return nil, false

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -255,8 +255,11 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 							WorkingDir:      "/",
 							Args: []string{
 								"--logdir=" + mountpath,
-								"--reload_interval",
-								"120",
+								// Set a reload interval of two minutes because the default of 5
+								// seconds costs can be very high when pulling data from Cloud
+								// Storage systems. See the tensorboard bug about reading from s3.
+								// https://github.com/tensorflow/tensorboard/issues/6564
+								"--reload_interval=120",
 								"--bind_all",
 							},
 							Ports: []corev1.ContainerPort{


### PR DESCRIPTION
The default reload interval of 5.0s can be very expensive for cloud file systems where each LIST and HEAD operation is billed.